### PR TITLE
Add code for detecting Android editor in device_editor_mock.gd

### DIFF
--- a/addons/playgama_bridge/modules/device/device_editor_mock.gd
+++ b/addons/playgama_bridge/modules/device/device_editor_mock.gd
@@ -1,4 +1,8 @@
 var type : get = _type_getter
 
 func _type_getter():
-	return Bridge.DeviceType.DESKTOP
+	match OS.get_name():
+		"Android":
+			return Bridge.DeviceType.MOBILE
+		_:
+			return Bridge.DeviceType.DESKTOP


### PR DESCRIPTION
It'll be helpful when working with the Godot Android Editor